### PR TITLE
Provide request validation on `add` api

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ instance.peerConn(instance.peers()[0]).request({
 ```
 
 <a name="add"></a>
-### instance.add(pattern, func)
+### instance.add(pattern, [schema,] func)
 
 Execute the given function when the received received requests
 matches the given pattern. The request is matched using
@@ -240,6 +240,23 @@ instance.add('parse', (req, reply) => {
 instance.add('parse', async (req, reply) => {
   const data = await something()
   return { data }
+})
+```
+
+#### Validation
+Upring offers you out of the box a nice and standard way to validate your requests, [*JSON schema*](http://json-schema.org/)!  
+Internally uses [ajv](https://github.com/epoberezkin/ajv/blob/master/README.md) to achieve the maximum speed and correctness.
+```js
+instance.add({ cmd: 'parse' }, {
+  type: 'object',
+  properties: {
+    cmd: { type: 'string' },
+    key: { type: 'string' },
+    value: { type: 'number' }
+  },
+  required: ['cmd']
+}, (req, reply) => {
+  reply(null, req)
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "then-sleep": "^1.0.1"
   },
   "dependencies": {
+    "ajv": "^5.2.2",
     "avvio": "^2.0.3",
     "bloomrun": "^3.0.0",
     "end-of-stream": "^1.4.0",

--- a/test/validation.test.js
+++ b/test/validation.test.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const test = require('tap').test
+const helper = require('./helper')
+
+const getKey = helper.getKey
+const bootTwo = helper.bootTwo
+
+test('should validate the request (valid)', { timeout: 5000 }, (t) => {
+  t.plan(6)
+
+  bootTwo(t, (i1, i2) => {
+    let i2Key = getKey(i2)
+
+    i1.request({
+      key: i2Key,
+      cmd: 'parse',
+      value: 42
+    }, (err, response) => {
+      t.error(err, 'no error')
+      t.deepEqual(response, {
+        replying: 'i2'
+      }, 'response matches')
+    })
+
+    i2.add({ cmd: 'parse' }, {
+      type: 'object',
+      properties: {
+        key: { type: 'string' },
+        cmd: { type: 'string' },
+        value: { type: 'number' }
+      }
+    }, (req, reply) => {
+      t.equal(req.key, i2Key, 'key matches')
+      t.equal(req.value, 42, 'other key matches')
+      reply(null, { replying: 'i2' })
+    })
+  })
+})
+
+test('should validate the request (not valid)', { timeout: 5000 }, (t) => {
+  t.plan(4)
+
+  bootTwo(t, (i1, i2) => {
+    let i2Key = getKey(i2)
+
+    i1.request({
+      key: i2Key,
+      cmd: 'parse',
+      value: 42
+    }, (err, response) => {
+      t.equal(err.message, '400')
+      t.is(typeof response, 'object')
+    })
+
+    i2.add({ cmd: 'parse' }, {
+      type: 'object',
+      properties: {
+        key: { type: 'string' },
+        cmd: { type: 'number' },
+        value: { type: 'number' }
+      }
+    }, (req, reply) => {
+      t.fail('this should not be called')
+    })
+  })
+})


### PR DESCRIPTION
As titled :)

```js
instance.add({ cmd: 'parse' }, {
  type: 'object',
  properties: {
    cmd: { type: 'string' },
    key: { type: 'string' },
    value: { type: 'number' }
  },
  required: ['cmd']
}, (req, reply) => {
  reply(null, req)
})
```