### PR TITLE
WIP: id and child logger for request and response

### DIFF
--- a/lib/tcp-server.js
+++ b/lib/tcp-server.js
@@ -9,6 +9,9 @@ module.exports = function serverPlugin (upring, opts, next) {
   upring._server.listen(opts.port, opts.host, onListen)
   upring._server.on('error', upring.emit.bind(upring, 'error'))
 
+  const genReqId = opts.genReqId || reqIdGenFactory()
+  upring.genReqId = genReqId
+
   function handler (stream) {
     if (upring.closed) {
       stream.on('error', noop)
@@ -24,12 +27,26 @@ module.exports = function serverPlugin (upring, opts, next) {
       upring.log.debug({ address: stream.address() }, 'closed connection')
       upring._inbound.delete(instance)
     })
-    instance.on('request', upring._dispatch)
+    instance.on('request', onRequest)
+  }
+
+  function onRequest (req, reply) {
+    req.id = genReqId(req)
+    req.log = upring.log.child({ reqId: req.id })
+    upring._dispatch(req, reply)
   }
 
   function onListen () {
     upring.log.debug({ address: upring._server.address() }, 'listening')
     next()
+  }
+
+  function reqIdGenFactory () {
+    var maxInt = 2147483647
+    var nextReqId = 0
+    return function _genReqId (req) {
+      return req.id || (nextReqId = (nextReqId + 1) & maxInt)
+    }
   }
 }
 

--- a/upring.js
+++ b/upring.js
@@ -208,6 +208,8 @@ UpRing.prototype.request = function (obj, callback, _count) {
     return
   }
 
+  obj.id = this.genReqId(obj)
+
   if (this._hashring.allocatedToMe(obj.key)) {
     this.log.trace({ msg: obj }, 'local call')
     this._dispatch(obj, dezalgo(callback))
@@ -248,6 +250,10 @@ UpRing.prototype.request = function (obj, callback, _count) {
           setTimeout(retry, 500, this, 'request', obj, callback, _count)
           return
         }
+      }
+      if (obj.id != null) {
+        result.id = obj.id
+        result.log = this.log.child({ reqId: result.id })
       }
       callback(err, result)
     })


### PR DESCRIPTION
As titled.
Is still a WIP because there are some points that we should discuss.

We are generating an id for every request that will be used also in the response, that id will be used also in the child logger. This is nice, because it will give us a tracker of what is happening to a specific request/response in the cluster, but what strategy we can use to keep that id unique? As you can see for the moment I used a very naive id generation function.

Almost all the test will fail because the response object will have the `id` and `log` fields.
Do we need to change the structure of the response object?
Something like:
```js
{
  key: String,
  id: Any,
  payload: Object, // the actual user message
  log: Object
}
```